### PR TITLE
ci20: Fix garbage in board_mfr environment string

### DIFF
--- a/board/imgtec/ci20/ci20.c
+++ b/board/imgtec/ci20/ci20.c
@@ -70,7 +70,7 @@ int misc_init_r(void)
 	setenv_ulong("board_date", otp.date);
 	memcpy(manufacturer, otp.manufacturer, 2);
 	manufacturer[2] = 0;
-	setenv("board_mfr", otp.manufacturer);
+	setenv("board_mfr", manufacturer);
 
 	return 0;
 }


### PR DESCRIPTION
The manufacturer string was copied out of the OTP into a temporary
buffer and null-terminated, but then the board_mfr variable was set
from the original, non-terminated string, resulting in garbage data
in the variable. Fix this.

Signed-off-by: Alex Smith alex.smith@imgtec.com
