### PR TITLE
Ci20 v2013.10 boot time

### DIFF
--- a/fs/ext4/ext4_common.c
+++ b/fs/ext4/ext4_common.c
@@ -1430,7 +1430,7 @@ static struct ext4_extent_header *ext4fs_get_extent_block
 			i++;
 			if (i >= le16_to_cpu(ext_block->eh_entries))
 				break;
-		} while (fileblock > le32_to_cpu(index[i].ei_block));
+		} while (fileblock >= le32_to_cpu(index[i].ei_block));
 
 		if (--i < 0)
 			return 0;

--- a/include/configs/ci20.h
+++ b/include/configs/ci20.h
@@ -71,10 +71,11 @@
 
 #define CONFIG_BOOTP_MASK	(CONFIG_BOOTP_DEFAUL)
 
-#define CONFIG_BOOTDELAY 2
+#define CONFIG_BOOTDELAY 1
 #define CONFIG_SYS_BOOTM_LEN (64 << 20)
 #define BOOTARGS_COMMON \
-	"console=ttyS4,115200 console=tty0 mem=256M@0x0 mem=768M@0x30000000 rootwait"
+	"console=ttyS4,115200 console=tty0 mem=256M@0x0 mem=768M@0x30000000 " \
+	"rootwait quiet"
 
 #ifdef CONFIG_SPL_MMC_SUPPORT
 

--- a/include/configs/ci20.h
+++ b/include/configs/ci20.h
@@ -90,9 +90,10 @@
 /* NAND defaults */
 
 #define CONFIG_BOOTARGS \
-	BOOTARGS_COMMON " ubi.mtd=3 root=ubi0:root rootfstype=ubifs rw"
+	BOOTARGS_COMMON " ubi.mtd=3 ubi.mtd=4 ubi.fm_autoconvert=1 " \
+	"root=ubi1:root rootfstype=ubifs rw"
 #define CONFIG_BOOTCOMMAND \
-	"run ethargs; mtdparts default; ubi part system; ubifsmount ubi:boot; " \
+	"run ethargs; mtdparts default; ubi part boot; ubifsmount ubi:boot; " \
 	"ubifsload 0x88000000 uImage; bootm 0x88000000"
 
 #endif /* !CONFIG_SPL_MMC_SUPPORT */
@@ -168,7 +169,7 @@
 #define CONFIG_MTD_DEVICE
 #define CONFIG_MTD_PARTITIONS
 #define MTDIDS_DEFAULT			"nand0=nand"
-#define MTDPARTS_DEFAULT		"mtdparts=nand:8m(uboot-spl),2m(uboot),2m(uboot-env),-(system)"
+#define MTDPARTS_DEFAULT		"mtdparts=nand:8m(uboot-spl),2m(uboot),2m(uboot-env),128m(boot),-(system)"
 
 /*
  * MMC

--- a/include/configs/ci20.h
+++ b/include/configs/ci20.h
@@ -170,7 +170,7 @@
 #define CONFIG_MTD_DEVICE
 #define CONFIG_MTD_PARTITIONS
 #define MTDIDS_DEFAULT			"nand0=nand"
-#define MTDPARTS_DEFAULT		"mtdparts=nand:8m(uboot-spl),2m(uboot),2m(uboot-env),128m(boot),-(system)"
+#define MTDPARTS_DEFAULT		"mtdparts=nand:8m(uboot-spl),2m(uboot),2m(uboot-env),64m(boot),-(system)"
 
 /*
  * MMC


### PR DESCRIPTION
These patches improve the ci20 boot time.
The first adds a 128Mb boot partition for the kernel so that uboot doesn't waste time scanning the whole flash, and also prevents it deleting the kernels UBI fastmap volume
The second reduces boor timeout and adds quiet to the kernel command line
