### PR TITLE
Android ci20 v2013.10: jz_mmc: Ensure the clock is activated for the MMC devices in use.

### DIFF
--- a/drivers/mmc/jz_mmc.c
+++ b/drivers/mmc/jz_mmc.c
@@ -290,12 +290,15 @@ void jz_mmc_init(int clock_div)
 	int i = 0;
 
 #if defined(CONFIG_JZ_MMC_MSC0) && (!defined(CONFIG_SPL_BUILD) || (CONFIG_JZ_MMC_SPLMSC == 0))
+	writel(readl(CPM_CLKGR0) & ~CPM_CLKGR0_MSC0, CPM_CLKGR0);
 	jz_mmc_init_one(i++, 0, MSC0_BASE, clock_div);
 #endif
 #if defined(CONFIG_JZ_MMC_MSC1) && (!defined(CONFIG_SPL_BUILD) || (CONFIG_JZ_MMC_SPLMSC == 1))
+	writel(readl(CPM_CLKGR0) & ~CPM_CLKGR0_MSC1, CPM_CLKGR0);
 	jz_mmc_init_one(i++, 1, MSC1_BASE, clock_div);
 #endif
 #if defined(CONFIG_JZ_MMC_MSC2) && (!defined(CONFIG_SPL_BUILD) || (CONFIG_JZ_MMC_SPLMSC == 2))
+	writel(readl(CPM_CLKGR0) & ~CPM_CLKGR0_MSC2, CPM_CLKGR0);
 	jz_mmc_init_one(i++, 2, MSC2_BASE, clock_div);
 #endif
 }


### PR DESCRIPTION
(This is the same as #16 but based on the Android ci20 branch)

The clock for the MMC devices needs to be activated by clearing the corresponding bits in CLKGR0. It has so far only worked when booting from SD card because the bootrom leaves it cleared.

This fixes #1.